### PR TITLE
Include updates from private development repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The two modes have the different command line options as below.
 ```console
 $ nanoprobe --help
 usage:
-  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --busyloop-txtstamp --reverse/--duplex [host]
-  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv] --busyloop-txtstamp
+  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --busyloop-txtstamp --pin-threads [x,y,z] --reverse/--duplex [host]
+  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv] --busyloop-txtstamp --pin-threads [x,y,z]
 ```
 
 - `--client`: Run in client mode, the IPv4 address of the server has to be provided as the **final** argument.
@@ -69,6 +69,7 @@ usage:
 - `--probe-schedule/-S <csv-file>`: Provide a schedule for the ping packets in a CSV with the delay and ping-size for each packet. The CSV format is `<delay>,<ping-size>` (with delay and ping-size specified as for the corresponding options) with one line per packet, no header. The test will run until each packet in the schedule has been sent. This option overrides any supplied delay, ping-size and count options. In order for the server to be able to follow a schedule (in the reverse and duplex modes) the server must be started with this option, the client will not share the schedule with the server.
 - `--pong-every/-y <n>`: Only pong (reply to) every n:th ping message. The value 0 will disable ponging altogether (NOTE: this may cause the application to timeout depending on the test duration and the supplied `timeout` value). Default is to pong every ping.
 - `--busyloop-txtstamp/-B`: Run a busyloop reading the socket error queue for TX timestamps instead of waiting for the availability of something on the error queue being signaled via `select()`. This can help with retrieving more hardware TX timestamps in high packet rate (low delay) scenarios.
+- `--pin-threads/-P <x,y,z>`: Pin the individual threads of nanoprobe to core x (main thread), y (TX timestamp fetching thread), and z (pong receive thread). This can be useful when sending packets at high rates (low delays) to reduce interference from CPU scheduling and migration.
 - `--reverse/-R`: Instead of the nanoprobe client pinging the server, request that the server pings the client. This can be useful if the client is behind NAT, so that the server and clients cannot simply swap places. This is mutually exclusive with the `duplex` option.
 - `--duplex/-D`: Instead of the nanoprobe server ponging the pings from the client, make it independently (although starting on the reception of the first ping from the client) send its own pings to the client. This is mutually exclusive with the `reverse` option.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The two modes have the different command line options as below.
 ```console
 $ nanoprobe --help
 usage:
-  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --busyloop-txtstamp --pin-threads [x,y,z] --reverse/--duplex [host]
+  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --busyloop-txtstamp --pin-threads [x,y,z] --compensate-drift --reverse/--duplex [host]
   server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv] --busyloop-txtstamp --pin-threads [x,y,z]
 ```
 
@@ -70,6 +70,7 @@ usage:
 - `--pong-every/-y <n>`: Only pong (reply to) every n:th ping message. The value 0 will disable ponging altogether (NOTE: this may cause the application to timeout depending on the test duration and the supplied `timeout` value). Default is to pong every ping.
 - `--busyloop-txtstamp/-B`: Run a busyloop reading the socket error queue for TX timestamps instead of waiting for the availability of something on the error queue being signaled via `select()`. This can help with retrieving more hardware TX timestamps in high packet rate (low delay) scenarios.
 - `--pin-threads/-P <x,y,z>`: Pin the individual threads of nanoprobe to core x (main thread), y (TX timestamp fetching thread), and z (pong receive thread). This can be useful when sending packets at high rates (low delays) to reduce interference from CPU scheduling and migration.
+- `--compensate-drift/-C`: Attempt to send packets so that the cumulative delay of all packets since the start of the test match the sending schedule rather than trying to hit the configured delay for each individual packet. If nanoprobe falls behind its configured sending schedule (regardless if it's a fixed-interval schedule from --delay or a --probe-schedule), this allows it to undershoot the target delay for subsequent packets to try and "catch up" to its original schedule.
 - `--reverse/-R`: Instead of the nanoprobe client pinging the server, request that the server pings the client. This can be useful if the client is behind NAT, so that the server and clients cannot simply swap places. This is mutually exclusive with the `duplex` option.
 - `--duplex/-D`: Instead of the nanoprobe server ponging the pings from the client, make it independently (although starting on the reception of the first ping from the client) send its own pings to the client. This is mutually exclusive with the `reverse` option.
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The two modes have the different command line options as below.
 ```console
 $ nanoprobe --help
 usage:
-  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --dummy-pkt [cnt] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --reverse/--duplex [host]
-  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --dummy-pkt [cnt] --probe-schedule [csv]
+  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --reverse/--duplex [host]
+  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv]
 ```
 
 - `--client`: Run in client mode, the IPv4 address of the server has to be provided as the **final** argument.
@@ -63,7 +63,6 @@ usage:
 - `--emulation/-e`: Use software timestamps from the nanoprobe process instead of hardware timestamps supplied by the NIC
 - `--timeout/-t <usec>`: Set the timeout value in microseconds for how long to wait for a ping or pong packet before failing. Sets the `SO_RCVTIMEO` socket option on the ping/pong socket. Default is 5 seconds.
 - `--busypoll/-b`: Set `SO_BUSY_POLL` socket option for ping/pong socket (see man socket(7) for details).
-- `--dummy-pkt/-x <n>`: Send n additional packets during each ping-pong transaction. This option produces broader bandwidth for the measurements stream. Inherited from nanoping but not really tested with nanoprobe.
 - `--timer/-T <sleep/busy>`: Determines how to wait for the required time between packets to achieve the target delay. The sleep option tries to sleep until the next packet needs to be sent, but this tends to be quite inaccurate at sub-millisecond timescales. The `busy` alternative instead busy loops until the next packet needs to be sent, which achieves much greater accuracy (typically within one microsecond) but at the cost of burning CPU cycles. Defaults to busy if delay <= 1ms, otherwise sleep.
 - `--ping-size/-s <bytes>`: The size of the ping packets (including the IP-header, but not the Ethernet header). Defaults to the smallest possible size (currently 44 bytes).
 - `--pong-size/-o <bytes>`: The size of the ping packets (including the IP-header, but not the Ethernet header). Defaults to the smallest possible size (currently 44 bytes).

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The two modes have the different command line options as below.
 ```console
 $ nanoprobe --help
 usage:
-  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --reverse/--duplex [host]
-  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv]
+  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --busyloop-txtstamp --reverse/--duplex [host]
+  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv] --busyloop-txtstamp
 ```
 
 - `--client`: Run in client mode, the IPv4 address of the server has to be provided as the **final** argument.
@@ -68,6 +68,7 @@ usage:
 - `--pong-size/-o <bytes>`: The size of the ping packets (including the IP-header, but not the Ethernet header). Defaults to the smallest possible size (currently 44 bytes).
 - `--probe-schedule/-S <csv-file>`: Provide a schedule for the ping packets in a CSV with the delay and ping-size for each packet. The CSV format is `<delay>,<ping-size>` (with delay and ping-size specified as for the corresponding options) with one line per packet, no header. The test will run until each packet in the schedule has been sent. This option overrides any supplied delay, ping-size and count options. In order for the server to be able to follow a schedule (in the reverse and duplex modes) the server must be started with this option, the client will not share the schedule with the server.
 - `--pong-every/-y <n>`: Only pong (reply to) every n:th ping message. The value 0 will disable ponging altogether (NOTE: this may cause the application to timeout depending on the test duration and the supplied `timeout` value). Default is to pong every ping.
+- `--busyloop-txtstamp/-B`: Run a busyloop reading the socket error queue for TX timestamps instead of waiting for the availability of something on the error queue being signaled via `select()`. This can help with retrieving more hardware TX timestamps in high packet rate (low delay) scenarios.
 - `--reverse/-R`: Instead of the nanoprobe client pinging the server, request that the server pings the client. This can be useful if the client is behind NAT, so that the server and clients cannot simply swap places. This is mutually exclusive with the `duplex` option.
 - `--duplex/-D`: Instead of the nanoprobe server ponging the pings from the client, make it independently (although starting on the reception of the first ping from the client) send its own pings to the client. This is mutually exclusive with the `reverse` option.
 

--- a/nanoprobe.1
+++ b/nanoprobe.1
@@ -47,6 +47,7 @@
 .Op Fl Fl pong-size Ar bytes | Fl o Ar bytes
 .Op Fl Fl probe-schedule Ar csv | Fl S Ar csv
 .Op Fl Fl pong-every Ar n | Fl y Ar n
+.Op Fl Fl busyloop-txtstamp | Fl B
 .Op Fl Fl reverse | Fl R
 .Op Fl Fl duplex | Fl D
 host
@@ -59,6 +60,7 @@ host
 .Op Fl Fl timeout Ar usec | Fl t Ar usec
 .Op Fl Fl busypoll Ar usec | Fl b Ar usec
 .Op Fl Fl probe-schedule Ar csv | Fl S Ar csv
+.Op Fl Fl busyloop-txtstamp | Fl B
 .\" ###### Description ######################################################
 .Sh DESCRIPTION
 .Nm nanoprobe
@@ -72,6 +74,8 @@ For example, minimum timestamping resolution is 12.5ns on the Intel X550 Etherne
 .Sh ARGUMENTS
 The following arguments may be provided:
 .Bl -tag -width indent
+.It Fl Fl busyloop-txtstamp | Fl B
+Run a busyloop reading the socket error queue for TX timestamps instead of waiting for the availability of something on the error queue being signaled via `select()`. This can help with retrieving more hardware TX timestamps in high packet rate (low delay) scenarios.
 .It Fl Fl busypoll Ar usec | Fl b Ar usec
 Set "SO_BUSY_POLL" socket option for ping/pong socket (see man socket(7) for details).
 .It Fl Fl client

--- a/nanoprobe.1
+++ b/nanoprobe.1
@@ -42,7 +42,6 @@
 .Op Fl Fl emulation | Fl e
 .Op Fl Fl timeout Ar usec | Fl t Ar usec
 .Op Fl Fl busypoll Ar usec | Fl b Ar usec
-.Op Fl Fl dummy-pkt Ar cnt | Fl x Ar cnt
 .Op Fl Fl timer Ar busy|sleep | Fl T Ar busy|sleep
 .Op Fl Fl ping-size Ar bytes | Fl s Ar bytes
 .Op Fl Fl pong-size Ar bytes | Fl o Ar bytes
@@ -59,7 +58,6 @@ host
 .Op Fl Fl emulation | Fl e
 .Op Fl Fl timeout Ar usec | Fl t Ar usec
 .Op Fl Fl busypoll Ar usec | Fl b Ar usec
-.Op Fl Fl dummy-pkt Ar cnt | Fl x Ar cnt
 .Op Fl Fl probe-schedule Ar csv | Fl S Ar csv
 .\" ###### Description ######################################################
 .Sh DESCRIPTION
@@ -82,8 +80,6 @@ Run in client mode, the IPv4 address of the server has to be provided as the fin
 The duration of the nanoprobe measurement in seconds. Set to 0 to run forever (only supported in the "forward" test direction)
 .It Fl Fl delay Ar usec | Fl d Ar usec
 The target time in microseconds between sending ping packets.
-.It Fl Fl dummy-pkt Ar cnt | Fl x Ar cnt
-Send n additional packets during each ping-pong transaction. This option produces broader bandwidth for the measurements stream. Inherited from nanoping but not really tested with nanoprobe.
 .It Fl Fl duplex | Fl D
 Instead of the nanoprobe server ponging the pings from the client, make it independently (although starting on the reception of the first ping from the client) send its own pings to the client. This is mutually exclusive with the "reverse" option.
 .It Fl Fl emulation | Fl e

--- a/nanoprobe.1
+++ b/nanoprobe.1
@@ -49,6 +49,7 @@
 .Op Fl Fl pong-every Ar n | Fl y Ar n
 .Op Fl Fl busyloop-txtstamp | Fl B
 .Op Fl Fl pin-threads Ar x,y,z | Fl P Ar x,y,z
+.Op Fl Fl compensate-drift | Fl C
 .Op Fl Fl reverse | Fl R
 .Op Fl Fl duplex | Fl D
 host
@@ -82,6 +83,8 @@ Run a busyloop reading the socket error queue for TX timestamps instead of waiti
 Set "SO_BUSY_POLL" socket option for ping/pong socket (see man socket(7) for details).
 .It Fl Fl client
 Run in client mode, the IPv4 address of the server has to be provided as the final argument.
+.It Fl Fl compensate-drift | Fl C
+Attempt to send packets so that the cumulative delay of all packets since the start of the test match the sending schedule rather than trying to hit the configured delay for each individual packet. If nanoprobe falls behind its configured sending schedule (regardless if it's a fixed-interval schedule from --delay or a --probe-schedule), this allows it to undershoot the target delay for subsequent packets to try and catch up to its original schedule.
 .It Fl Fl count Ar sec | Fl n Ar sec
 The duration of the nanoprobe measurement in seconds. Set to 0 to run forever (only supported in the "forward" test direction)
 .It Fl Fl delay Ar usec | Fl d Ar usec

--- a/nanoprobe.1
+++ b/nanoprobe.1
@@ -48,6 +48,7 @@
 .Op Fl Fl probe-schedule Ar csv | Fl S Ar csv
 .Op Fl Fl pong-every Ar n | Fl y Ar n
 .Op Fl Fl busyloop-txtstamp | Fl B
+.Op Fl Fl pin-threads Ar x,y,z | Fl P Ar x,y,z
 .Op Fl Fl reverse | Fl R
 .Op Fl Fl duplex | Fl D
 host
@@ -61,6 +62,7 @@ host
 .Op Fl Fl busypoll Ar usec | Fl b Ar usec
 .Op Fl Fl probe-schedule Ar csv | Fl S Ar csv
 .Op Fl Fl busyloop-txtstamp | Fl B
+.Op Fl Fl pin-threads Ar x,y,z | Fl P Ar x,y,z
 .\" ###### Description ######################################################
 .Sh DESCRIPTION
 .Nm nanoprobe
@@ -92,6 +94,8 @@ Use software timestamps from the nanoprobe process instead of hardware timestamp
 Specify interface name to send/receive ping-pong packets.
 .It Fl Fl log Ar logfile | Fl l Ar logfile
 Log per-packet timestamps in a CSV-format to the provided file.
+.It Fl Fl pin-threads Ar x,y,z | Fl P Ar x,y,z
+Pin the individual threads of nanoprobe to core x (main thread), y (TX timestamp fetching thread), and z (pong receive thread). This can be useful when sending packets at high rates (low delays) to reduce interference from CPU scheduling and migration.
 .It Fl Fl ping-size Ar bytes | Fl s Ar bytes
 The size of the ping packets (including the IP-header, but not the Ethernet header). Defaults to the smallest possible size (currently 44 bytes).
 .It Fl Fl pong-every Ar n | Fl y Ar n

--- a/nanoprobe.bash-completion
+++ b/nanoprobe.bash-completion
@@ -45,14 +45,15 @@ _nanoprobe()
 
    case "${prev}" in
       #  ====== Generic value ===============================================
-      --busypoll   | -b | \
-      --count      | -n | \
-      --delay      | -d | \
-      --port       | -p | \
-      --timeout    | -t | \
-      --ping-size  | -s | \
-      --pong-size  | -o | \
-      --pong-every | -y)
+      --busypoll    | -b | \
+      --count       | -n | \
+      --delay       | -d | \
+      --port        | -p | \
+      --timeout     | -t | \
+      --ping-size   | -s | \
+      --pong-size   | -o | \
+      --pong-every  | -y | \
+      --pin-threads | -P)
          return
          ;;
 
@@ -107,7 +108,9 @@ _nanoprobe()
 --log
 -n
 -o
+-P
 -p
+--pin-threads
 --ping-size
 --pong-every
 --pong-size

--- a/nanoprobe.bash-completion
+++ b/nanoprobe.bash-completion
@@ -50,7 +50,6 @@ _nanoprobe()
       --delay      | -d | \
       --port       | -p | \
       --timeout    | -t | \
-      --dummy-pkt  | -x | \
       --ping-size  | -s | \
       --pong-size  | -o | \
       --pong-every | -y)
@@ -97,7 +96,6 @@ _nanoprobe()
 -D
 -d
 --delay
---dummy-pkt
 --duplex
 -e
 --emulation
@@ -122,7 +120,6 @@ _nanoprobe()
 -t
 --timeout
 --timer
--x
 -y
 "
    # shellcheck disable=SC2207

--- a/nanoprobe.bash-completion
+++ b/nanoprobe.bash-completion
@@ -89,7 +89,9 @@ _nanoprobe()
 
    # ====== All options =====================================================
    local opts="
+-B
 -b
+--busyloop-txtstamp
 --busypoll
 --client
 --count

--- a/nanoprobe.bash-completion
+++ b/nanoprobe.bash-completion
@@ -95,6 +95,8 @@ _nanoprobe()
 --busyloop-txtstamp
 --busypoll
 --client
+-C
+--compensate-drift
 --count
 -D
 -d

--- a/nanoprobe.h
+++ b/nanoprobe.h
@@ -111,7 +111,6 @@ ssize_t nanoping_send_one(struct nanoping_instance *ins,
 			  struct nanoping_send_request *request,
 			  void *payload_buf, size_t payload_len);
 int nanoping_txs_one(struct nanoping_instance *ins);
-void nanoping_reset_state(struct nanoping_instance *ins);
 void nanoping_finish(struct nanoping_instance *ins);
 
 #endif

--- a/nanoprobe.h
+++ b/nanoprobe.h
@@ -110,7 +110,7 @@ ssize_t nanoping_receive_one(struct nanoping_instance *ins,
 ssize_t nanoping_send_one(struct nanoping_instance *ins,
 			  struct nanoping_send_request *request,
 			  void *payload_buf, size_t payload_len);
-int nanoping_txs_one(struct nanoping_instance *ins);
+int nanoping_txs_one(struct nanoping_instance *ins, bool busyloop);
 void nanoping_finish(struct nanoping_instance *ins);
 
 #endif

--- a/nanoprobe.h
+++ b/nanoprobe.h
@@ -53,7 +53,6 @@
 
 struct nanoping_instance {
     int fd;
-    int nots_fd;
     struct sockaddr_in myaddr;
     bool server;
     bool emulation;
@@ -77,18 +76,12 @@ enum nanoping_msg_type {
     msg_pong,
     msg_fin,
     msg_fin_ack,
-    msg_dummy,
 };
 
 struct nanoping_send_request {
     enum nanoping_msg_type type;
     uint64_t seq;
     struct sockaddr_in remaddr;
-};
-
-struct nanoping_send_dummies_request {
-    struct sockaddr_in remaddr;
-    int nmsg;
 };
 
 struct nanoping_receive_result {
@@ -117,8 +110,6 @@ ssize_t nanoping_receive_one(struct nanoping_instance *ins,
 ssize_t nanoping_send_one(struct nanoping_instance *ins,
 			  struct nanoping_send_request *request,
 			  void *payload_buf, size_t payload_len);
-int nanoping_send_dummies(struct nanoping_instance *ins,
-    struct nanoping_send_dummies_request *request);
 int nanoping_txs_one(struct nanoping_instance *ins);
 void nanoping_reset_state(struct nanoping_instance *ins);
 void nanoping_finish(struct nanoping_instance *ins);

--- a/nanoprobe_common.c
+++ b/nanoprobe_common.c
@@ -308,18 +308,7 @@ struct nanoping_instance *nanoping_init(char *interface, char *port,
         return NULL;
     }
 
-    if ((ins->nots_fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
-        perror("socket");
-        return NULL;
-    }
-
     if ((res = setsockopt(ins->fd, SOL_SOCKET, SO_BINDTODEVICE, interface,
-                    strlen(interface)+1)) < 0) {
-        perror("SO_BINDTODEVICE");
-        return NULL;
-    }
-
-    if ((res = setsockopt(ins->nots_fd, SOL_SOCKET, SO_BINDTODEVICE, interface,
                     strlen(interface)+1)) < 0) {
         perror("SO_BINDTODEVICE");
         return NULL;
@@ -339,17 +328,6 @@ struct nanoping_instance *nanoping_init(char *interface, char *port,
             return NULL;
         }
 
-        if ((res = setsockopt(ins->nots_fd, SOL_SOCKET, SO_RCVTIMEO, (char *)&timeo,
-                        sizeof(timeo))) < 0) {
-            perror("SO_RCVTIMEO");
-            return NULL;
-        }
-
-        if ((res = setsockopt(ins->nots_fd, SOL_SOCKET, SO_SNDTIMEO, (char *)&timeo,
-                        sizeof(timeo))) < 0) {
-            perror("SO_SNDTIMEO");
-            return NULL;
-        }
     }
 
     ins->myaddr.sin_family = AF_INET;
@@ -497,52 +475,6 @@ ssize_t nanoping_send_one(struct nanoping_instance *ins,
 
     ins->pkt_transmitted++;
     return siz;
-}
-
-static int send_dummies_common(struct nanoping_instance *ins, struct sockaddr_in *remaddr, int nmsg, struct iovec *iovs)
-{
-    struct mmsghdr mmsgs[nmsg];
-    int res;
-
-    memset(mmsgs, 0, sizeof(mmsgs));
-    for (int i = 0; i < nmsg; i++) {
-        mmsgs[i].msg_hdr.msg_name = remaddr;
-        mmsgs[i].msg_hdr.msg_namelen = sizeof(struct sockaddr_in);
-        mmsgs[i].msg_hdr.msg_iov = &iovs[i];
-        mmsgs[i].msg_hdr.msg_iovlen = 1;
-    }
-
-    res = sendmmsg(ins->nots_fd, mmsgs, nmsg, 0);
-    if (!res) {
-        fprintf(stderr, "zero dummy packets sent\n");
-    } else if (res < 0) {
-        perror("sendmmsg");
-    }
-    ins->pkt_transmitted += res;
-    return res;
-}
-
-static int send_dummies_msg(struct nanoping_instance *ins, struct sockaddr_in *remaddr, int nmsg)
-{
-    struct nanoping_msg msgs[nmsg];
-    struct iovec iovs[nmsg];
-
-    memset(msgs, 0, sizeof(msgs));
-    memset(iovs, 0, sizeof(iovs));
-    for (int i = 0; i < nmsg; i++) {
-        msgs[i].seq = UINT64_MAX;
-        msgs[i].type = msg_dummy;
-        iovs[i].iov_base = &msgs[i];
-        iovs[i].iov_len = sizeof(struct nanoping_msg);
-    }
-    return send_dummies_common(ins, remaddr, nmsg, iovs);
-}
-
-int nanoping_send_dummies(struct nanoping_instance *ins, struct nanoping_send_dummies_request *request)
-{
-    assert(ins && request);
-
-    return send_dummies_msg(ins, &request->remaddr, request->nmsg);
 }
 
 int nanoping_txs_one(struct nanoping_instance *ins)

--- a/nanoprobe_common.c
+++ b/nanoprobe_common.c
@@ -477,9 +477,47 @@ ssize_t nanoping_send_one(struct nanoping_instance *ins,
     return siz;
 }
 
-int nanoping_txs_one(struct nanoping_instance *ins)
+static ssize_t rcv_errorqueue_msg(int fd, struct msghdr *m, bool busyloop)
 {
     fd_set exceptfds;
+    ssize_t siz;
+    int res;
+
+    errno = 0;
+
+    if (busyloop) {
+        while ((siz = recvmsg(fd, m, MSG_ERRQUEUE)) < 0 && errno == EAGAIN);
+    } else {
+        FD_ZERO(&exceptfds);
+        FD_SET(fd, &exceptfds);
+        if ((res = select(fd + 1, NULL, NULL, &exceptfds, NULL)) == 0) {
+            fprintf(stderr, "Timeout to receive tx timestamp\n");
+            return -1;
+        } else if (res < 0) {
+            perror("select(errqueue)");
+            return -1;
+        } else if (!FD_ISSET(fd, &exceptfds)) {
+            fprintf(stderr, "No message available on error queue\n");
+            return -1;
+        }
+
+        siz = recvmsg(fd, m, MSG_ERRQUEUE);
+    }
+
+    if (siz < 0) {
+        if (errno == EAGAIN) {
+            fprintf(stderr, "recvmsg(errqueue): Request timed out.\n");
+            return siz;
+        }
+        perror("recvmsg(errqueue)");
+        return siz;
+    }
+
+    return siz;
+}
+
+int nanoping_txs_one(struct nanoping_instance *ins, bool busyloop)
+{
     struct msghdr m = {0};
     char pktbuf[2048];
     char ctrlbuf[1024];
@@ -507,18 +545,6 @@ int nanoping_txs_one(struct nanoping_instance *ins)
         log_pkt_tstamp(ins, etxs.seq, &etxs.stamp, etxs.type, etxs.size, true);
         return 0;
     }
-    FD_ZERO(&exceptfds);
-    FD_SET(ins->fd, &exceptfds);
-    if ((res = select(ins->fd + 1, NULL, NULL, &exceptfds, NULL)) == 0) {
-        fprintf(stderr, "Timeout to receive tx timestamp\n");
-        return -1;
-    } else if (res < 0) {
-        perror("select");
-        return res;
-    } else if (!FD_ISSET(ins->fd, &exceptfds)) {
-        fprintf(stderr, "No message available on error queue\n");
-        return -1;
-    }
 
     m.msg_iov = &iov;
     m.msg_iovlen = 1;
@@ -527,15 +553,10 @@ int nanoping_txs_one(struct nanoping_instance *ins)
     m.msg_control = ctrlbuf;
     m.msg_controllen = sizeof(ctrlbuf);
 
-    errno  = 0;
-    if ((siz = recvmsg(ins->fd, &m, MSG_ERRQUEUE | MSG_DONTWAIT)) < 0) {
-        if (errno == EAGAIN) {
-            fprintf(stderr, "recvmsg(errqueue): Request timed out.\n");
-            return siz;
-        }
-        perror("recvmsg(errqueue)");
+    siz = rcv_errorqueue_msg(ins->fd, &m, busyloop);
+    if (siz < 0)
         return siz;
-    }
+
     if (siz < sizeof(*msg) + TOT_LINKHDR_SIZE) {
         fprintf(stderr, "Invalid packet size on txs callback\n");
         return -1;

--- a/nanoprobe_common.c
+++ b/nanoprobe_common.c
@@ -556,14 +556,6 @@ int nanoping_txs_one(struct nanoping_instance *ins)
     return 0;
 }
 
-void nanoping_reset_state(struct nanoping_instance *ins)
-{
-    ins->pkt_received = 0;
-    ins->pkt_transmitted = 0;
-    ins->rxs_collected = 0;
-    ins->txs_collected = 0;
-}
-
 void nanoping_finish(struct nanoping_instance *ins)
 {
     assert(ins);

--- a/nanoprobe_common.c
+++ b/nanoprobe_common.c
@@ -480,7 +480,6 @@ ssize_t nanoping_send_one(struct nanoping_instance *ins,
 int nanoping_txs_one(struct nanoping_instance *ins)
 {
     fd_set exceptfds;
-    struct sockaddr_in remaddr;
     struct msghdr m = {0};
     char pktbuf[2048];
     char ctrlbuf[1024];
@@ -523,8 +522,8 @@ int nanoping_txs_one(struct nanoping_instance *ins)
 
     m.msg_iov = &iov;
     m.msg_iovlen = 1;
-    m.msg_name = (void *)&remaddr;
-    m.msg_namelen = sizeof(remaddr);
+    m.msg_name = NULL;
+    m.msg_namelen = 0;
     m.msg_control = ctrlbuf;
     m.msg_controllen = sizeof(ctrlbuf);
 

--- a/nanoprobe_main.c
+++ b/nanoprobe_main.c
@@ -1,3 +1,4 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -63,11 +64,19 @@ struct nanoprobe_client_opts {
 struct nanoprobe_receive_thread_args {
     struct nanoping_instance *ins;
     struct sockaddr_in *remaddr;
+    int pin_to_core;
 };
 
 struct nanoprobe_txs_thread_args {
     struct nanoping_instance *ins;
+    int pin_to_core;
     bool busyloop;
+};
+
+struct nanoprobe_core_pinning {
+    int main_thread_core;
+    int txs_thread_core;
+    int rcv_thread_core;
 };
 
 static struct option longopts[] = {
@@ -87,6 +96,7 @@ static struct option longopts[] = {
     {"probe-schedule",    required_argument, NULL, 'S'},
     {"pong-every",        required_argument, NULL, 'y'},
     {"busyloop-txtstamp", no_argument,       NULL, 'B'},
+    {"pin-threads",       required_argument, NULL, 'P'},
     {"help",              no_argument,       NULL, 'h'},
     {0,                   0,                 0,     0 }
 };
@@ -101,8 +111,8 @@ static pthread_cond_t ping_wait_cond;
 static void usage(void)
 {
     fprintf(stderr, "usage:\n");
-    fprintf(stderr, "  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --busyloop-txtstamp --reverse/--duplex [host]\n");
-    fprintf(stderr, "  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv] --busyloop-txtstamp\n");
+    fprintf(stderr, "  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --busyloop-txtstamp --pin-threads [x,y,z] --reverse/--duplex [host]\n");
+    fprintf(stderr, "  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv] --busyloop-txtstamp --pin-threads [x,y,z]\n");
 }
 
 inline static double percent_ulong(unsigned long v1, unsigned long v2)
@@ -356,6 +366,70 @@ err:
     return err;
 }
 
+static int parse_cpucore_list(const char *_str,
+                              struct nanoprobe_core_pinning *core_pinning)
+{
+
+    char *cpunum, *nxt_pos;
+    char str[1024];
+    long long val;
+    int cpus[3];
+    int err, i;
+
+    strncpy(str, _str, sizeof(str));
+    cpunum = strtok_r(str, ",", &nxt_pos);
+
+    for (i = 0; i < ARRAY_SIZE(cpus); i++) {
+        if (!cpunum) {
+            fprintf(stderr,
+                    "'%s' is not a valid CPU-core list, should be of the format 'X,Y,Z'\n",
+                    _str);
+            return -EINVAL;
+        }
+
+        err = parse_bounded_integer(&val, cpunum, 0, 1024);
+        if (err) {
+            fprintf(
+                stderr,
+                "%s is not a valid CPU number, should be in the range [0, 1024]\n",
+                cpunum);
+            return err;
+        }
+
+        cpus[i] = val;
+
+        cpunum = strtok_r(NULL, ",", &nxt_pos);
+    }
+
+    core_pinning->main_thread_core = cpus[0];
+    core_pinning->txs_thread_core = cpus[1];
+    core_pinning->rcv_thread_core = cpus[2];
+
+    return 0;
+}
+
+static int pin_thread_to_core(int cpu_core)
+{
+    cpu_set_t pin_cores;
+    int err;
+
+    // Any negative cpu_core value means don't pin (NOP)
+    if (cpu_core < 0)
+        return 0;
+
+    CPU_ZERO(&pin_cores);
+    CPU_SET(cpu_core, &pin_cores);
+
+    err = pthread_setaffinity_np(pthread_self(), sizeof(pin_cores), &pin_cores);
+    if (err) {
+        fprintf(stderr, "pthread_setaffinity_np(core=%d) failed: %s\n",
+                cpu_core, strerror(err));
+        return -err;
+    }
+
+    return 0;
+}
+
 static bool is_from_expected_sender(const struct nanoping_receive_result *receive_result,
                                     const struct sockaddr_in *remaddr)
 {
@@ -383,17 +457,21 @@ static void prepare_server_reply(struct nanoping_send_request *send_request,
 
 static void init_receivethread_args(struct nanoprobe_receive_thread_args *args,
                                     struct nanoping_instance *ins,
-                                    struct sockaddr_in *remaddr)
+                                    struct sockaddr_in *remaddr,
+                                    const struct nanoprobe_core_pinning *pinning)
 {
     args->ins = ins;
     args->remaddr = remaddr;
+    args->pin_to_core = pinning->rcv_thread_core;
 }
 
 static void init_txsthread_args(struct nanoprobe_txs_thread_args *args,
-                                struct nanoping_instance *ins, bool busyloop)
+                                struct nanoping_instance *ins, bool busyloop,
+                                const struct nanoprobe_core_pinning *pinning)
 {
     args->ins = ins;
     args->busyloop = busyloop;
+    args->pin_to_core = pinning->txs_thread_core;
 }
 
 static void *process_client_receive_task(void *arg)
@@ -402,6 +480,11 @@ static void *process_client_receive_task(void *arg)
     struct nanoping_receive_result receive_result = {0};
     struct nanoping_send_request send_request = {0};
     ssize_t siz;
+    int err;
+
+    err = pin_thread_to_core(args->pin_to_core);
+    if (err)
+        exit(EXIT_FAILURE);
 
     for (;;) {
         siz = nanoping_receive_one(args->ins, &receive_result, NULL, NULL);
@@ -501,6 +584,11 @@ static void *process_client_signal_task(void *arg)
 static void *process_txs_task(void *arg)
 {
     struct nanoprobe_txs_thread_args *args = arg;
+    int err;
+
+    err = pin_thread_to_core(args->pin_to_core);
+    if (err)
+        exit(EXIT_FAILURE);
 
     for (;;)
         nanoping_txs_one(args->ins, args->busyloop);
@@ -1162,7 +1250,8 @@ static void wait_for_ping(enum timer_type ttype)
 
 static int run_client(struct nanoping_instance *ins, char *host, char *port,
                       struct nanoprobe_client_opts *client_opts,
-                      struct probe_schedule *schedule, bool busyloop_txs)
+                      struct probe_schedule *schedule, bool busyloop_txs,
+                      const struct nanoprobe_core_pinning *pinning)
 {
     struct addrinfo *reminfo;
     struct pthread_thread signal_thread = {0};
@@ -1182,8 +1271,8 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
     }
 
     init_receivethread_args(&recvt_args, ins,
-                            (struct sockaddr_in *)reminfo->ai_addr);
-    init_txsthread_args(&txst_args, ins, busyloop_txs);
+                            (struct sockaddr_in *)reminfo->ai_addr, pinning);
+    init_txsthread_args(&txst_args, ins, busyloop_txs, pinning);
     err = setup_client_threads(&recvt_args, &txst_args, &signal_thread,
                                &txs_thread, &receive_thread);
     if (err) {
@@ -1233,7 +1322,8 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
 }
 
 static int run_server(struct nanoping_instance *ins, char *port,
-                      struct probe_schedule *schedule, bool busyloop_txs)
+                      struct probe_schedule *schedule, bool busyloop_txs,
+                      const struct nanoprobe_core_pinning *pinning)
 {
     struct pthread_thread signal_thread = {0};
     struct pthread_thread txs_thread = {0};
@@ -1250,7 +1340,7 @@ static int run_server(struct nanoping_instance *ins, char *port,
     pthread_cond_init(&ping_wait_cond, NULL);
     pthread_mutex_init(&ping_wait_lock, NULL);
 
-    init_txsthread_args(&txst_args, ins, busyloop_txs);
+    init_txsthread_args(&txst_args, ins, busyloop_txs, pinning);
     err = setup_server_threads(&txst_args, &txs_thread);
     if (err) {
         fprintf(stderr, "Failed setting up server threads: %s\n", strerror(-err));
@@ -1271,7 +1361,7 @@ static int run_server(struct nanoping_instance *ins, char *port,
     } else {
         // reverse or duplex - switch to client-mode
         err = close_threads(threads, ARRAY_SIZE(threads));
-        init_receivethread_args(&recvt_args, ins, &remaddr);
+        init_receivethread_args(&recvt_args, ins, &remaddr, pinning);
         err = err ?: setup_client_threads(&recvt_args, &txst_args,
                                           &signal_thread, &txs_thread,
                                           &receive_thread);
@@ -1318,6 +1408,11 @@ int main(int argc, char **argv)
         .ttype = timer_invalid,
         .direction = test_forward,
     };
+    struct nanoprobe_core_pinning core_pinning = {
+        .main_thread_core = -1,
+        .txs_thread_core = -1,
+        .rcv_thread_core = -1,
+    };
     struct probe_schedule schedule = { 0 };
     enum nanoping_mode mode = mode_none;
     char *interface = NULL;
@@ -1330,6 +1425,7 @@ int main(int argc, char **argv)
     int c, res, nargc = argc;
     bool reverse = false, duplex = false;
     bool busyloop_txs = false;
+    int err;
 
     if (argc >= 2) {
         if (!strcmp(argv[1], "--server")) {
@@ -1346,7 +1442,7 @@ int main(int argc, char **argv)
 	usage();
 	return EXIT_FAILURE;
     }
-    while ((c = getopt_long(nargc, argv + 1, "i:n:d:p:l:et:s:o:b:T:RDS:y:Bh", longopts, NULL)) != -1) {
+    while ((c = getopt_long(nargc, argv + 1, "i:n:d:p:l:et:s:o:b:T:RDS:y:BP:h", longopts, NULL)) != -1) {
         switch (c) {
             case 'i':
                 interface = optarg;
@@ -1416,6 +1512,11 @@ int main(int argc, char **argv)
             case 'B':
                 busyloop_txs = true;
                 break;
+            case 'P':
+                err = parse_cpucore_list(optarg, &core_pinning);
+                if (err)
+                    return EXIT_FAILURE;
+		break;
             case 'h':
             default:
                 usage();
@@ -1464,12 +1565,17 @@ int main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 
+    err = pin_thread_to_core(core_pinning.main_thread_core);
+    if (err)
+        exit(EXIT_FAILURE);
+
     if (mode == mode_client) {
         res = run_client(ins, host, port, &client_opts,
-			 schedule.len > 0 ? &schedule : NULL, busyloop_txs);
+			 schedule.len > 0 ? &schedule : NULL, busyloop_txs,
+                         &core_pinning);
     } else {
         res = run_server(ins, port, schedule.len > 0 ? &schedule : NULL,
-			 busyloop_txs);
+			 busyloop_txs, &core_pinning);
     }
     nanoping_finish(ins);
     return res;

--- a/nanoprobe_main.c
+++ b/nanoprobe_main.c
@@ -59,6 +59,7 @@ struct nanoprobe_client_opts {
     uint32_t pong_every;
     enum timer_type ttype;
     enum test_direction direction;
+    bool compensate_drift;
 };
 
 struct nanoprobe_receive_thread_args {
@@ -97,6 +98,7 @@ static struct option longopts[] = {
     {"pong-every",        required_argument, NULL, 'y'},
     {"busyloop-txtstamp", no_argument,       NULL, 'B'},
     {"pin-threads",       required_argument, NULL, 'P'},
+    {"compensate-drift",  no_argument,       NULL, 'C'},
     {"help",              no_argument,       NULL, 'h'},
     {0,                   0,                 0,     0 }
 };
@@ -111,7 +113,7 @@ static pthread_cond_t ping_wait_cond;
 static void usage(void)
 {
     fprintf(stderr, "usage:\n");
-    fprintf(stderr, "  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --busyloop-txtstamp --pin-threads [x,y,z] --reverse/--duplex [host]\n");
+    fprintf(stderr, "  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --busyloop-txtstamp --pin-threads [x,y,z] --compensate-drift --reverse/--duplex [host]\n");
     fprintf(stderr, "  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv] --busyloop-txtstamp --pin-threads [x,y,z]\n");
 }
 
@@ -883,7 +885,7 @@ static int client_sendloop(const struct sockaddr_in *remaddr,
                 return res;
             }
 
-        } else {
+        } else if (!opts->compensate_drift) {
             next_start = now;
         }
 
@@ -1048,10 +1050,11 @@ static void server_log_client_connection(const struct sockaddr_in *remaddr)
 
 static void server_log_clientopts(const struct nanoprobe_client_opts *client_opts)
 {
-    printf("Client using settings: count: %u s, delay: %u us, ping-padding %u bytes, pong-padding %u bytes, pong-every: %u, timer: %s (%d), direction: %s (%d)\n",
+    printf("Client using settings: count: %u s, delay: %u us, ping-padding %u bytes, pong-padding %u bytes, pong-every: %u, timer: %s (%d), compensate-drift: %s, direction: %s (%d)\n",
            client_opts->count, client_opts->delay, client_opts->ping_pad,
            client_opts->pong_pad, client_opts->pong_every,
            timertype_to_str(client_opts->ttype), client_opts->ttype,
+           client_opts->compensate_drift ? "true" : "false",
            testdirection_to_str(client_opts->direction),
            client_opts->direction);
 }
@@ -1394,6 +1397,7 @@ int main(int argc, char **argv)
         .pong_every = 1,
         .ttype = timer_invalid,
         .direction = test_forward,
+        .compensate_drift = false,
     };
     struct nanoprobe_core_pinning core_pinning = {
         .main_thread_core = -1,
@@ -1429,7 +1433,7 @@ int main(int argc, char **argv)
 	usage();
 	return EXIT_FAILURE;
     }
-    while ((c = getopt_long(nargc, argv + 1, "i:n:d:p:l:et:s:o:b:T:RDS:y:BP:h", longopts, NULL)) != -1) {
+    while ((c = getopt_long(nargc, argv + 1, "i:n:d:p:l:et:s:o:b:T:RDS:y:BP:Ch", longopts, NULL)) != -1) {
         switch (c) {
             case 'i':
                 interface = optarg;
@@ -1504,6 +1508,9 @@ int main(int argc, char **argv)
                 if (err)
                     return EXIT_FAILURE;
 		break;
+            case 'C':
+                client_opts.compensate_drift = true;
+                break;
             case 'h':
             default:
                 usage();

--- a/nanoprobe_main.c
+++ b/nanoprobe_main.c
@@ -60,7 +60,7 @@ struct nanoprobe_client_opts {
     enum test_direction direction;
 };
 
-struct nanoprobe_recieve_thread_args {
+struct nanoprobe_receive_thread_args {
     struct nanoping_instance *ins;
     struct sockaddr_in *remaddr;
 };
@@ -375,9 +375,17 @@ static void prepare_server_reply(struct nanoping_send_request *send_request,
     send_request->type = msg_type;
 }
 
+static void init_receivethread_args(struct nanoprobe_receive_thread_args *args,
+                                    struct nanoping_instance *ins,
+                                    struct sockaddr_in *remaddr)
+{
+    args->ins = ins;
+    args->remaddr = remaddr;
+}
+
 static void *process_client_receive_task(void *arg)
 {
-    struct nanoprobe_recieve_thread_args *args = arg;
+    struct nanoprobe_receive_thread_args *args = arg;
     struct nanoping_receive_result receive_result = {0};
     struct nanoping_send_request send_request = {0};
     ssize_t siz;
@@ -581,7 +589,7 @@ static int setup_txtstamp_thread(struct pthread_thread *txs_thread,
 }
 
 static int setup_receive_thread(struct pthread_thread *receive_thread,
-                                struct nanoprobe_recieve_thread_args *args)
+                                struct nanoprobe_receive_thread_args *args)
 {
     int err;
 
@@ -598,7 +606,7 @@ static int setup_receive_thread(struct pthread_thread *receive_thread,
     return 0;
 }
 
-static int setup_client_threads(struct nanoprobe_recieve_thread_args *args,
+static int setup_client_threads(struct nanoprobe_receive_thread_args *args,
                                 struct pthread_thread *signal_thread,
                                 struct pthread_thread *txs_thread,
                                 struct pthread_thread *receive_thread)
@@ -1147,7 +1155,7 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
     struct pthread_thread txs_thread = {0};
     struct pthread_thread receive_thread = {0};
     struct pthread_thread *threads[] = {&signal_thread, &txs_thread, &receive_thread};
-    struct nanoprobe_recieve_thread_args recv_thread_args;
+    struct nanoprobe_receive_thread_args recvt_args;
     struct timespec started, finished, duration;
     ssize_t pktsize = 0;
     int err;
@@ -1158,9 +1166,9 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
         return EXIT_FAILURE;
     }
 
-    recv_thread_args.ins = ins;
-    recv_thread_args.remaddr = (struct sockaddr_in *)reminfo->ai_addr;
-    err = setup_client_threads(&recv_thread_args, &signal_thread, &txs_thread,
+    init_receivethread_args(&recvt_args, ins,
+                            (struct sockaddr_in *)reminfo->ai_addr);
+    err = setup_client_threads(&recvt_args, &signal_thread, &txs_thread,
                                &receive_thread);
     if (err) {
         fprintf(stderr, "Failed setting up client threads: %s\n", strerror(-err));
@@ -1168,7 +1176,7 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
     }
 
     printf("Attempting to connect to %s:%s...\n", host, port);
-    err = client_handshake(recv_thread_args.remaddr, ins, client_opts);
+    err = client_handshake(recvt_args.remaddr, ins, client_opts);
     if (err) {
         fprintf(stderr, "Failed connecting to server: %s\n", strerror(-err));
         return EXIT_FAILURE;
@@ -1215,7 +1223,7 @@ static int run_server(struct nanoping_instance *ins, char *port,
     struct pthread_thread txs_thread = {0};
     struct pthread_thread receive_thread = {0};
     struct pthread_thread *threads[] = {&signal_thread, &txs_thread, &receive_thread};
-    struct nanoprobe_recieve_thread_args recv_thread_args;
+    struct nanoprobe_receive_thread_args recvt_args;
     struct timespec started, finished, duration;
     struct nanoprobe_client_opts client_opts;
     struct sockaddr_in remaddr;
@@ -1245,9 +1253,8 @@ static int run_server(struct nanoping_instance *ins, char *port,
     } else {
         // reverse or duplex - switch to client-mode
         err = close_threads(threads, ARRAY_SIZE(threads));
-        recv_thread_args.ins = ins;
-        recv_thread_args.remaddr = &remaddr;
-        err = err ?: setup_client_threads(&recv_thread_args, &signal_thread,
+        init_receivethread_args(&recvt_args, ins, &remaddr);
+        err = err ?: setup_client_threads(&recvt_args, &signal_thread,
                                           &txs_thread, &receive_thread);
 
         if (client_opts.direction == test_duplex)

--- a/nanoprobe_main.c
+++ b/nanoprobe_main.c
@@ -1500,8 +1500,8 @@ int main(int argc, char **argv)
                 duplex = true;
                 break;
             case 'S':
-                if (parse_probesched_csv(optarg, &schedule) != 0 ||
-                    schedule.len == 0) {
+                err = parse_probesched_csv(optarg, &schedule);
+                if (err || schedule.len == 0) {
                     fprintf(stderr, "Failed parsing CSV %s\n", optarg);
                     return EXIT_FAILURE;
                 }

--- a/nanoprobe_main.c
+++ b/nanoprobe_main.c
@@ -383,7 +383,6 @@ static void *process_client_receive_task(void *arg)
     struct nanoping_send_request send_request = {0};
     ssize_t siz;
 
-    nanoping_wait_for_receive(args->ins);
     for (;;) {
         siz = nanoping_receive_one(args->ins, &receive_result, NULL, NULL);
         if (siz < 0)

--- a/nanoprobe_main.c
+++ b/nanoprobe_main.c
@@ -1193,11 +1193,13 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
         return EXIT_FAILURE;
     }
 
-    printf("nanoprobe %s:%s...\n", host, port);
-
+    printf("Attempting to connect to %s:%s...\n", host, port);
     err = client_handshake(recv_thread_args.remaddr, ins, client_opts);
-    if (err)
+    if (err) {
+        fprintf(stderr, "Failed connecting to server: %s\n", strerror(-err));
         return EXIT_FAILURE;
+    }
+    printf("Connection established\n");
 
     if (client_opts->direction == test_reverse) {
         err = close_threads(threads, ARRAY_SIZE(threads));
@@ -1259,8 +1261,10 @@ static int run_server(struct nanoping_instance *ins, char *port, int dummy_pkt,
     printf("nanoprobe server started on port %s.\n", port);
 
     err = server_handshake(ins, &remaddr, &client_opts, schedule != NULL);
-    if (err)
+    if (err) {
+        fprintf(stderr, "Failed connecting to client: %s\n", strerror(-err));
         return EXIT_FAILURE;
+    }
 
     if (client_opts.direction == test_forward) {
         err = server_echoloop(ins, &remaddr, &client_opts, dummy_pkt,

--- a/nanoprobe_main.c
+++ b/nanoprobe_main.c
@@ -74,7 +74,6 @@ static struct option longopts[] = {
     {"emulation",      no_argument,       NULL, 'e'},
     {"timeout",        required_argument, NULL, 't'},
     {"busypoll",       required_argument, NULL, 'b'},
-    {"dummy-pkt",      required_argument, NULL, 'x'},
     {"ping-size",      required_argument, NULL, 's'},
     {"pong-size",      required_argument, NULL, 'o'},
     {"timer",          required_argument, NULL, 'T'},
@@ -96,8 +95,8 @@ static pthread_cond_t ping_wait_cond;
 static void usage(void)
 {
     fprintf(stderr, "usage:\n");
-    fprintf(stderr, "  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --dummy-pkt [cnt] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --reverse/--duplex [host]\n");
-    fprintf(stderr, "  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --dummy-pkt [cnt] --probe-schedule [csv]\n");
+    fprintf(stderr, "  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --reverse/--duplex [host]\n");
+    fprintf(stderr, "  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv]\n");
 }
 
 inline static double percent_ulong(unsigned long v1, unsigned long v2)
@@ -425,7 +424,6 @@ static void *process_client_receive_task(void *arg)
                 }
                 break;
             case msg_pong:
-            case msg_dummy:
                 /* do nothing */
                 break;
             case msg_fin_ack:
@@ -744,7 +742,7 @@ static int wait_until_next_interval(uint64_t start_ns, uint64_t interval_ns,
 static int client_sendloop(const struct sockaddr_in *remaddr,
                            struct nanoping_instance *ins,
                            struct nanoprobe_client_opts *opts,
-                           struct probe_schedule *schedule, int dummy_pkt,
+                           struct probe_schedule *schedule,
                            uint64_t *next_seq, ssize_t *sent_pktsize,
                            struct timespec *start, struct timespec *end)
 {
@@ -777,17 +775,6 @@ static int client_sendloop(const struct sockaddr_in *remaddr,
 
         if (!pktsize)
             pktsize = siz;
-
-        if (dummy_pkt > 0) {
-            struct nanoping_send_dummies_request dummies_request;
-            memcpy(&dummies_request.remaddr, remaddr,
-                   sizeof(dummies_request.remaddr));
-            dummies_request.nmsg = dummy_pkt;
-
-            res = nanoping_send_dummies(ins, &dummies_request);
-            if (res <= 0)
-                return res;
-        }
 
         if (delay > 0) {
             if (schedule)
@@ -822,15 +809,15 @@ static int run_client_ping_sequence(struct nanoping_instance *ins,
                                     struct sockaddr_in *remaddr,
                                     struct nanoprobe_client_opts *opts,
                                     struct probe_schedule *schedule,
-                                    int dummy_pkt, ssize_t *packet_size,
+                                    ssize_t *packet_size,
                                     struct timespec *start,
                                     struct timespec *end)
 {
     uint64_t next_seq;
     int res;
 
-    res = client_sendloop(remaddr, ins, opts, schedule, dummy_pkt, &next_seq,
-                          packet_size, start, end);
+    res = client_sendloop(remaddr, ins, opts, schedule, &next_seq, packet_size,
+                          start, end);
     if (res)
         return res;
 
@@ -1051,9 +1038,8 @@ static int server_handle_foreign_packet(struct nanoping_instance *ins,
 static int server_handle_ping(struct nanoping_instance *ins,
                               const struct nanoping_receive_result *receive_result,
                               const struct nanoprobe_client_opts *client_opts,
-                              int dummy_pkt, ssize_t *pktsize)
+                              ssize_t *pktsize)
 {
-    struct nanoping_send_dummies_request dummies_request;
     struct nanoping_send_request send_request = {0};
     int res;
 
@@ -1090,17 +1076,6 @@ static int server_handle_ping(struct nanoping_instance *ins,
             if (pktsize)
                 *pktsize = res;
 
-            if (dummy_pkt) {
-                dummies_request.remaddr = receive_result->remaddr;
-                dummies_request.nmsg = dummy_pkt;
-
-                res = nanoping_send_dummies(ins, &dummies_request);
-                if (res <= 0)
-                    return res;
-            }
-            break;
-        case msg_dummy:
-            /* do nothing */
             break;
         default:
             fprintf(stderr, "Illegal packet received, ignoring.\n");
@@ -1112,7 +1087,7 @@ static int server_handle_ping(struct nanoping_instance *ins,
 static int server_echoloop(struct nanoping_instance *ins,
                            const struct sockaddr_in *remaddr,
                            const struct nanoprobe_client_opts *client_opts,
-                           int dummy_pkt, ssize_t *sent_pktsize,
+                           ssize_t *sent_pktsize,
                            struct timespec *start, struct timespec *end)
 {
     struct nanoping_receive_result receive_result;
@@ -1128,7 +1103,7 @@ static int server_echoloop(struct nanoping_instance *ins,
             return res;
 
         if (is_from_expected_sender(&receive_result, remaddr)) {
-            res = server_handle_ping(ins, &receive_result, client_opts, dummy_pkt,
+            res = server_handle_ping(ins, &receive_result, client_opts,
                                      pktsize == 0 ? &pktsize : NULL);
 
             if (first_rcv == 0 && receive_result.type == msg_ping)
@@ -1164,7 +1139,7 @@ static void wait_for_ping(enum timer_type ttype)
 }
 
 static int run_client(struct nanoping_instance *ins, char *host, char *port,
-                      int dummy_pkt, struct nanoprobe_client_opts *client_opts,
+                      struct nanoprobe_client_opts *client_opts,
                       struct probe_schedule *schedule)
 {
     struct addrinfo *reminfo;
@@ -1204,8 +1179,7 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
         err = close_threads(threads, ARRAY_SIZE(threads));
         err = err ?: setup_server_threads(ins, &txs_thread);
         err = err ?: server_echoloop(ins, (struct sockaddr_in *)reminfo->ai_addr,
-                                     client_opts, dummy_pkt, &pktsize,
-                                     &started, &finished);
+                                     client_opts, &pktsize, &started, &finished);
     } else {
         // In duplex mode - give server some time to transition to client mode
         if (client_opts->direction == test_duplex)
@@ -1215,7 +1189,7 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
             alarm(client_opts->count);
 
         err = run_client_ping_sequence(ins, (struct sockaddr_in *)reminfo->ai_addr,
-                                       client_opts, schedule, dummy_pkt, &pktsize,
+                                       client_opts, schedule, &pktsize,
                                        &started, &finished);
     }
     if (err) {
@@ -1234,7 +1208,7 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
     return EXIT_SUCCESS;
 }
 
-static int run_server(struct nanoping_instance *ins, char *port, int dummy_pkt,
+static int run_server(struct nanoping_instance *ins, char *port,
                       struct probe_schedule *schedule)
 {
     struct pthread_thread signal_thread = {0};
@@ -1266,8 +1240,8 @@ static int run_server(struct nanoping_instance *ins, char *port, int dummy_pkt,
     }
 
     if (client_opts.direction == test_forward) {
-        err = server_echoloop(ins, &remaddr, &client_opts, dummy_pkt,
-                              &pktsize, &started, &finished);
+        err = server_echoloop(ins, &remaddr, &client_opts, &pktsize,
+                              &started, &finished);
     } else {
         // reverse or duplex - switch to client-mode
         err = close_threads(threads, ARRAY_SIZE(threads));
@@ -1286,7 +1260,7 @@ static int run_server(struct nanoping_instance *ins, char *port, int dummy_pkt,
         if (!schedule)
             alarm(client_opts.count);
         err = err ?: run_client_ping_sequence(ins, &remaddr, &client_opts,
-                                              schedule, dummy_pkt, &pktsize,
+                                              schedule, &pktsize,
                                               &started, &finished);
     }
     if (err) {
@@ -1327,7 +1301,6 @@ int main(int argc, char **argv)
     bool emulation = false;
     int timeout = 5000000;
     int busy_poll = 0;
-    int dummy_pkt = 0;
     int c, res, nargc = argc;
     bool reverse = false, duplex = false;
 
@@ -1385,9 +1358,6 @@ int main(int argc, char **argv)
                 break;
             case 'b':
                 busy_poll = atoi(optarg);
-                break;
-            case 'x':
-                dummy_pkt = atoi(optarg);
                 break;
             case 'T':
                 client_opts.ttype = str_to_timertype(optarg);
@@ -1465,11 +1435,10 @@ int main(int argc, char **argv)
     }
 
     if (mode == mode_client) {
-        res = run_client(ins, host, port, dummy_pkt, &client_opts,
+        res = run_client(ins, host, port, &client_opts,
                          schedule.len > 0 ? &schedule : NULL);
     } else {
-        res = run_server(ins, port, dummy_pkt,
-                         schedule.len > 0 ? &schedule : NULL);
+        res = run_server(ins, port, schedule.len > 0 ? &schedule : NULL);
     }
     nanoping_finish(ins);
     return res;

--- a/nanoprobe_main.c
+++ b/nanoprobe_main.c
@@ -60,6 +60,11 @@ struct nanoprobe_client_opts {
     enum test_direction direction;
 };
 
+struct nanoprobe_recieve_thread_args {
+    struct nanoping_instance *ins;
+    struct sockaddr_in *remaddr;
+};
+
 static struct option longopts[] = {
     {"interface",      required_argument, NULL, 'i'},
     {"count",          required_argument, NULL, 'n'},
@@ -346,18 +351,39 @@ err:
     return err;
 }
 
+static bool is_from_expected_sender(const struct nanoping_receive_result *receive_result,
+                                    const struct sockaddr_in *remaddr)
+{
+    return memcmp(&receive_result->remaddr, remaddr, sizeof(*remaddr)) == 0;
+}
+
+static void client_handle_foreign_packet(const struct nanoping_receive_result *receive_result)
+{
+    char ip_str[INET6_ADDRSTRLEN] = "";
+
+    inet_ntop(receive_result->remaddr.sin_family,
+              &receive_result->remaddr.sin_addr, ip_str, sizeof(ip_str));
+    fprintf(stderr, "Received packet from unexpected destination %s:%u\n",
+            ip_str, ntohs(receive_result->remaddr.sin_port));
+    return;
+}
+
 static void *process_client_receive_task(void *arg)
 {
-    struct nanoping_instance *ins = (struct nanoping_instance *)arg;
+    struct nanoprobe_recieve_thread_args *args = arg;
     struct nanoping_receive_result receive_result = {0};
     ssize_t siz;
 
-
-    nanoping_wait_for_receive(ins);
+    nanoping_wait_for_receive(args->ins);
     for (;;) {
-        siz = nanoping_receive_one(ins, &receive_result, NULL, NULL);
+        siz = nanoping_receive_one(args->ins, &receive_result, NULL, NULL);
         if (siz < 0)
             exit(EXIT_FAILURE);
+
+        if (!is_from_expected_sender(&receive_result, args->remaddr)) {
+            client_handle_foreign_packet(&receive_result);
+            continue;
+        }
 
         switch (receive_result.type) {
             case msg_syn_ack:
@@ -537,14 +563,14 @@ static int setup_txtstamp_thread(struct pthread_thread *txs_thread,
 }
 
 static int setup_receive_thread(struct pthread_thread *receive_thread,
-                                struct nanoping_instance *ins)
+                                struct nanoprobe_recieve_thread_args *args)
 {
     int err;
 
     receive_thread->valid = false;
 
     if ((err = pthread_create(&receive_thread->thread, NULL,
-                              process_client_receive_task, ins))) {
+                              process_client_receive_task, args))) {
         errno = err;
         perror("pthread_create(receive_thread)");
         return -err;
@@ -554,7 +580,7 @@ static int setup_receive_thread(struct pthread_thread *receive_thread,
     return 0;
 }
 
-static int setup_client_threads(struct nanoping_instance *ins,
+static int setup_client_threads(struct nanoprobe_recieve_thread_args *args,
                                 struct pthread_thread *signal_thread,
                                 struct pthread_thread *txs_thread,
                                 struct pthread_thread *receive_thread)
@@ -571,11 +597,11 @@ static int setup_client_threads(struct nanoping_instance *ins,
     if (err)
         return err;
 
-    err = setup_txtstamp_thread(txs_thread, ins);
+    err = setup_txtstamp_thread(txs_thread, args->ins);
     if (err)
         goto err_threads;
 
-    err = setup_receive_thread(receive_thread, ins);
+    err = setup_receive_thread(receive_thread, args);
     if (err)
         goto err_threads;
 
@@ -1089,7 +1115,7 @@ static int server_echoloop(struct nanoping_instance *ins,
         if (res < 0)
             return res;
 
-        if (memcmp(&receive_result.remaddr, remaddr, sizeof(*remaddr)) == 0) {
+        if (is_from_expected_sender(&receive_result, remaddr)) {
             res = server_handle_ping(ins, &receive_result, client_opts, dummy_pkt,
                                      pktsize == 0 ? &pktsize : NULL);
 
@@ -1134,6 +1160,7 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
     struct pthread_thread txs_thread = {0};
     struct pthread_thread receive_thread = {0};
     struct pthread_thread *threads[] = {&signal_thread, &txs_thread, &receive_thread};
+    struct nanoprobe_recieve_thread_args recv_thread_args;
     struct timespec started, finished, duration;
     ssize_t pktsize = 0;
     int err;
@@ -1144,7 +1171,10 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
         return EXIT_FAILURE;
     }
 
-    err = setup_client_threads(ins, &signal_thread, &txs_thread, &receive_thread);
+    recv_thread_args.ins = ins;
+    recv_thread_args.remaddr = (struct sockaddr_in *)reminfo->ai_addr;
+    err = setup_client_threads(&recv_thread_args, &signal_thread, &txs_thread,
+                               &receive_thread);
     if (err) {
         fprintf(stderr, "Failed setting up client threads: %s\n", strerror(-err));
         return EXIT_FAILURE;
@@ -1152,8 +1182,7 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
 
     printf("nanoprobe %s:%s...\n", host, port);
 
-    err = client_handshake((struct sockaddr_in *)reminfo->ai_addr, ins,
-                           client_opts);
+    err = client_handshake(recv_thread_args.remaddr, ins, client_opts);
     if (err)
         return EXIT_FAILURE;
 
@@ -1198,6 +1227,7 @@ static int run_server(struct nanoping_instance *ins, char *port, int dummy_pkt,
     struct pthread_thread txs_thread = {0};
     struct pthread_thread receive_thread = {0};
     struct pthread_thread *threads[] = {&signal_thread, &txs_thread, &receive_thread};
+    struct nanoprobe_recieve_thread_args recv_thread_args;
     struct timespec started, finished, duration;
     struct nanoprobe_client_opts client_opts;
     struct sockaddr_in remaddr;
@@ -1225,8 +1255,10 @@ static int run_server(struct nanoping_instance *ins, char *port, int dummy_pkt,
     } else {
         // reverse or duplex - switch to client-mode
         err = close_threads(threads, ARRAY_SIZE(threads));
-        err = err ?: setup_client_threads(ins, &signal_thread, &txs_thread,
-                                          &receive_thread);
+        recv_thread_args.ins = ins;
+        recv_thread_args.remaddr = &remaddr;
+        err = err ?: setup_client_threads(&recv_thread_args, &signal_thread,
+                                          &txs_thread, &receive_thread);
 
         if (client_opts.direction == test_duplex)
             // In duplex mode, wait for first ping from client

--- a/nanoprobe_main.c
+++ b/nanoprobe_main.c
@@ -65,24 +65,30 @@ struct nanoprobe_receive_thread_args {
     struct sockaddr_in *remaddr;
 };
 
+struct nanoprobe_txs_thread_args {
+    struct nanoping_instance *ins;
+    bool busyloop;
+};
+
 static struct option longopts[] = {
-    {"interface",      required_argument, NULL, 'i'},
-    {"count",          required_argument, NULL, 'n'},
-    {"delay",          required_argument, NULL, 'd'},
-    {"port",           required_argument, NULL, 'p'},
-    {"log",            required_argument, NULL, 'l'},
-    {"emulation",      no_argument,       NULL, 'e'},
-    {"timeout",        required_argument, NULL, 't'},
-    {"busypoll",       required_argument, NULL, 'b'},
-    {"ping-size",      required_argument, NULL, 's'},
-    {"pong-size",      required_argument, NULL, 'o'},
-    {"timer",          required_argument, NULL, 'T'},
-    {"reverse",        no_argument,       NULL, 'R'},
-    {"duplex",         no_argument,       NULL, 'D'},
-    {"probe-schedule", required_argument, NULL, 'S'},
-    {"pong-every",     required_argument, NULL, 'y'},
-    {"help",           no_argument,       NULL, 'h'},
-    {0,                0,                 0,     0 }
+    {"interface",         required_argument, NULL, 'i'},
+    {"count",             required_argument, NULL, 'n'},
+    {"delay",             required_argument, NULL, 'd'},
+    {"port",              required_argument, NULL, 'p'},
+    {"log",               required_argument, NULL, 'l'},
+    {"emulation",         no_argument,       NULL, 'e'},
+    {"timeout",           required_argument, NULL, 't'},
+    {"busypoll",          required_argument, NULL, 'b'},
+    {"ping-size",         required_argument, NULL, 's'},
+    {"pong-size",         required_argument, NULL, 'o'},
+    {"timer",             required_argument, NULL, 'T'},
+    {"reverse",           no_argument,       NULL, 'R'},
+    {"duplex",            no_argument,       NULL, 'D'},
+    {"probe-schedule",    required_argument, NULL, 'S'},
+    {"pong-every",        required_argument, NULL, 'y'},
+    {"busyloop-txtstamp", no_argument,       NULL, 'B'},
+    {"help",              no_argument,       NULL, 'h'},
+    {0,                   0,                 0,     0 }
 };
 
 static atomic_bool signal_initialized       = false;
@@ -95,8 +101,8 @@ static pthread_cond_t ping_wait_cond;
 static void usage(void)
 {
     fprintf(stderr, "usage:\n");
-    fprintf(stderr, "  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --reverse/--duplex [host]\n");
-    fprintf(stderr, "  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv]\n");
+    fprintf(stderr, "  client: nanoprobe --client --interface [nic] --count [sec] --delay [usec] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --timer [timer-type] --ping-size [bytes] --pong-size [bytes] --probe-schedule [csv] --pong-every [n] --busyloop-txtstamp --reverse/--duplex [host]\n");
+    fprintf(stderr, "  server: nanoprobe --server --interface [nic] --port [port] --log [logfile] --emulation --timeout [usec] --busypoll [usec] --probe-schedule [csv] --busyloop-txtstamp\n");
 }
 
 inline static double percent_ulong(unsigned long v1, unsigned long v2)
@@ -383,6 +389,13 @@ static void init_receivethread_args(struct nanoprobe_receive_thread_args *args,
     args->remaddr = remaddr;
 }
 
+static void init_txsthread_args(struct nanoprobe_txs_thread_args *args,
+                                struct nanoping_instance *ins, bool busyloop)
+{
+    args->ins = ins;
+    args->busyloop = busyloop;
+}
+
 static void *process_client_receive_task(void *arg)
 {
     struct nanoprobe_receive_thread_args *args = arg;
@@ -487,10 +500,10 @@ static void *process_client_signal_task(void *arg)
 
 static void *process_txs_task(void *arg)
 {
-    struct nanoping_instance *ins = (struct nanoping_instance *)arg;
+    struct nanoprobe_txs_thread_args *args = arg;
 
     for (;;)
-        nanoping_txs_one(ins);
+        nanoping_txs_one(args->ins, args->busyloop);
     return NULL;
 }
 
@@ -571,14 +584,14 @@ static int setup_singal_handling(struct pthread_thread *signal_thread)
 }
 
 static int setup_txtstamp_thread(struct pthread_thread *txs_thread,
-                                 struct nanoping_instance *ins)
+                                 struct nanoprobe_txs_thread_args *args)
 {
     int err;
 
     txs_thread->valid = false;
 
     if ((err = pthread_create(&txs_thread->thread, NULL, process_txs_task,
-                              ins))) {
+                              args))) {
         errno = err;
         perror("pthread_create(txs_thread)");
         return -err;
@@ -606,7 +619,8 @@ static int setup_receive_thread(struct pthread_thread *receive_thread,
     return 0;
 }
 
-static int setup_client_threads(struct nanoprobe_receive_thread_args *args,
+static int setup_client_threads(struct nanoprobe_receive_thread_args *rcvt_args,
+                                struct nanoprobe_txs_thread_args *txst_args,
                                 struct pthread_thread *signal_thread,
                                 struct pthread_thread *txs_thread,
                                 struct pthread_thread *receive_thread)
@@ -623,11 +637,11 @@ static int setup_client_threads(struct nanoprobe_receive_thread_args *args,
     if (err)
         return err;
 
-    err = setup_txtstamp_thread(txs_thread, args->ins);
+    err = setup_txtstamp_thread(txs_thread, txst_args);
     if (err)
         goto err_threads;
 
-    err = setup_receive_thread(receive_thread, args);
+    err = setup_receive_thread(receive_thread, rcvt_args);
     if (err)
         goto err_threads;
 
@@ -638,10 +652,10 @@ err_threads:
     return err;
 }
 
-static int setup_server_threads(struct nanoping_instance *ins,
+static int setup_server_threads(struct nanoprobe_txs_thread_args *args,
                                 struct pthread_thread *txs_thread)
 {
-    return setup_txtstamp_thread(txs_thread, ins);
+    return setup_txtstamp_thread(txs_thread, args);
 }
 
 static int client_handshake(const struct sockaddr_in *remaddr,
@@ -1148,7 +1162,7 @@ static void wait_for_ping(enum timer_type ttype)
 
 static int run_client(struct nanoping_instance *ins, char *host, char *port,
                       struct nanoprobe_client_opts *client_opts,
-                      struct probe_schedule *schedule)
+                      struct probe_schedule *schedule, bool busyloop_txs)
 {
     struct addrinfo *reminfo;
     struct pthread_thread signal_thread = {0};
@@ -1156,6 +1170,7 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
     struct pthread_thread receive_thread = {0};
     struct pthread_thread *threads[] = {&signal_thread, &txs_thread, &receive_thread};
     struct nanoprobe_receive_thread_args recvt_args;
+    struct nanoprobe_txs_thread_args txst_args;
     struct timespec started, finished, duration;
     ssize_t pktsize = 0;
     int err;
@@ -1168,8 +1183,9 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
 
     init_receivethread_args(&recvt_args, ins,
                             (struct sockaddr_in *)reminfo->ai_addr);
-    err = setup_client_threads(&recvt_args, &signal_thread, &txs_thread,
-                               &receive_thread);
+    init_txsthread_args(&txst_args, ins, busyloop_txs);
+    err = setup_client_threads(&recvt_args, &txst_args, &signal_thread,
+                               &txs_thread, &receive_thread);
     if (err) {
         fprintf(stderr, "Failed setting up client threads: %s\n", strerror(-err));
         return EXIT_FAILURE;
@@ -1185,7 +1201,7 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
 
     if (client_opts->direction == test_reverse) {
         err = close_threads(threads, ARRAY_SIZE(threads));
-        err = err ?: setup_server_threads(ins, &txs_thread);
+        err = err ?: setup_server_threads(&txst_args, &txs_thread);
         err = err ?: server_echoloop(ins, (struct sockaddr_in *)reminfo->ai_addr,
                                      client_opts, &pktsize, &started, &finished);
     } else {
@@ -1217,13 +1233,14 @@ static int run_client(struct nanoping_instance *ins, char *host, char *port,
 }
 
 static int run_server(struct nanoping_instance *ins, char *port,
-                      struct probe_schedule *schedule)
+                      struct probe_schedule *schedule, bool busyloop_txs)
 {
     struct pthread_thread signal_thread = {0};
     struct pthread_thread txs_thread = {0};
     struct pthread_thread receive_thread = {0};
     struct pthread_thread *threads[] = {&signal_thread, &txs_thread, &receive_thread};
     struct nanoprobe_receive_thread_args recvt_args;
+    struct nanoprobe_txs_thread_args txst_args;
     struct timespec started, finished, duration;
     struct nanoprobe_client_opts client_opts;
     struct sockaddr_in remaddr;
@@ -1233,7 +1250,8 @@ static int run_server(struct nanoping_instance *ins, char *port,
     pthread_cond_init(&ping_wait_cond, NULL);
     pthread_mutex_init(&ping_wait_lock, NULL);
 
-    err = setup_server_threads(ins, &txs_thread);
+    init_txsthread_args(&txst_args, ins, busyloop_txs);
+    err = setup_server_threads(&txst_args, &txs_thread);
     if (err) {
         fprintf(stderr, "Failed setting up server threads: %s\n", strerror(-err));
         return EXIT_FAILURE;
@@ -1254,8 +1272,9 @@ static int run_server(struct nanoping_instance *ins, char *port,
         // reverse or duplex - switch to client-mode
         err = close_threads(threads, ARRAY_SIZE(threads));
         init_receivethread_args(&recvt_args, ins, &remaddr);
-        err = err ?: setup_client_threads(&recvt_args, &signal_thread,
-                                          &txs_thread, &receive_thread);
+        err = err ?: setup_client_threads(&recvt_args, &txst_args,
+                                          &signal_thread, &txs_thread,
+                                          &receive_thread);
 
         if (client_opts.direction == test_duplex)
             // In duplex mode, wait for first ping from client
@@ -1310,6 +1329,7 @@ int main(int argc, char **argv)
     int busy_poll = 0;
     int c, res, nargc = argc;
     bool reverse = false, duplex = false;
+    bool busyloop_txs = false;
 
     if (argc >= 2) {
         if (!strcmp(argv[1], "--server")) {
@@ -1326,7 +1346,7 @@ int main(int argc, char **argv)
 	usage();
 	return EXIT_FAILURE;
     }
-    while ((c = getopt_long(nargc, argv + 1, "i:n:d:p:l:et:s:o:b:T:RDS:y:h", longopts, NULL)) != -1) {
+    while ((c = getopt_long(nargc, argv + 1, "i:n:d:p:l:et:s:o:b:T:RDS:y:Bh", longopts, NULL)) != -1) {
         switch (c) {
             case 'i':
                 interface = optarg;
@@ -1393,6 +1413,9 @@ int main(int argc, char **argv)
             case 'y':
                 client_opts.pong_every = atoi(optarg);
                 break;
+            case 'B':
+                busyloop_txs = true;
+                break;
             case 'h':
             default:
                 usage();
@@ -1443,9 +1466,10 @@ int main(int argc, char **argv)
 
     if (mode == mode_client) {
         res = run_client(ins, host, port, &client_opts,
-                         schedule.len > 0 ? &schedule : NULL);
+			 schedule.len > 0 ? &schedule : NULL, busyloop_txs);
     } else {
-        res = run_server(ins, port, schedule.len > 0 ? &schedule : NULL);
+        res = run_server(ins, port, schedule.len > 0 ? &schedule : NULL,
+			 busyloop_txs);
     }
     nanoping_finish(ins);
     return res;

--- a/nanoprobe_main.c
+++ b/nanoprobe_main.c
@@ -833,22 +833,6 @@ static int wait_until(uint64_t time_ns, enum timer_type ttype)
     return 0;
 }
 
-static int wait_until_next_interval(uint64_t start_ns, uint64_t interval_ns,
-                                    enum timer_type ttype)
-{
-    uint64_t now, next_interval;
-
-    now = clock_gettime_ns(CLOCK_MONOTONIC);
-
-    if (now < start_ns)
-        return -ETIME;
-
-    next_interval = now - ((now - start_ns) % interval_ns);
-    next_interval += interval_ns;
-
-    return wait_until(next_interval, ttype);
-}
-
 static int client_sendloop(const struct sockaddr_in *remaddr,
                            struct nanoping_instance *ins,
                            struct nanoprobe_client_opts *opts,
@@ -856,14 +840,15 @@ static int client_sendloop(const struct sockaddr_in *remaddr,
                            uint64_t *next_seq, ssize_t *sent_pktsize,
                            struct timespec *start, struct timespec *end)
 {
+    uint64_t start_send, current_start, now, next_start, delay, i;
     struct nanoping_send_request send_request;
-    uint64_t start_send, start_round, delay, i;
     ssize_t siz, pkt_pad, pktsize = 0;
     int res;
 
     memcpy(&send_request.remaddr, remaddr, sizeof(send_request.remaddr));
     send_request.type = msg_ping;
     start_send = clock_gettime_ns(CLOCK_MONOTONIC);
+    next_start = start_send;
 
     for (i = 1; !atomic_load(&signal_handled); i++) {
         if (schedule) {
@@ -872,12 +857,12 @@ static int client_sendloop(const struct sockaddr_in *remaddr,
 
             pkt_pad = schedule->entries[i - 1].pad_bytes;
             delay = schedule->entries[i - 1].delay;
-            start_round = clock_gettime_ns(CLOCK_MONOTONIC);
         } else {
             pkt_pad = opts->ping_pad;
             delay = opts->delay;
         }
 
+        current_start = next_start;
         send_request.seq = i;
         siz = nanoping_send_one(ins, &send_request, NULL, pkt_pad);
         if (siz < 0)
@@ -886,18 +871,20 @@ static int client_sendloop(const struct sockaddr_in *remaddr,
         if (!pktsize)
             pktsize = siz;
 
-        if (delay > 0) {
-            if (schedule)
-                // For non-fixed delays, the interval algorithm does not work
-                res = wait_until(start_round + delay * NS_PER_US, opts->ttype);
-            else
-                res = wait_until_next_interval(start_send, delay * NS_PER_US,
-                                           opts->ttype);
+        next_start = current_start + delay * NS_PER_US;
+        now = clock_gettime_ns(CLOCK_MONOTONIC);
+
+        if (now < next_start) {
+            res = wait_until(next_start, opts->ttype);
+
             if (res < 0 && res != EINTR) {
                 fprintf(stderr, "Failed waiting for next ping: %s\n",
                         strerror(-res));
                 return res;
             }
+
+        } else {
+            next_start = now;
         }
 
     }

--- a/nanoprobe_main.c
+++ b/nanoprobe_main.c
@@ -368,10 +368,19 @@ static void client_handle_foreign_packet(const struct nanoping_receive_result *r
     return;
 }
 
+static void prepare_server_reply(struct nanoping_send_request *send_request,
+                                 const struct nanoping_receive_result *receive_result,
+                                 enum nanoping_msg_type msg_type) {
+    send_request->seq = receive_result->seq;
+    send_request->remaddr = receive_result->remaddr;
+    send_request->type = msg_type;
+}
+
 static void *process_client_receive_task(void *arg)
 {
     struct nanoprobe_recieve_thread_args *args = arg;
     struct nanoping_receive_result receive_result = {0};
+    struct nanoping_send_request send_request = {0};
     ssize_t siz;
 
     nanoping_wait_for_receive(args->ins);
@@ -386,6 +395,18 @@ static void *process_client_receive_task(void *arg)
         }
 
         switch (receive_result.type) {
+            case msg_syn:
+                /*
+                 * If we were initially a server that has switched into
+                 * "client-mode" (for the reverse or duplex option),
+                 * resend SYN-ACK to (original) client to handle potential
+                 * loss of the initial SYN-ACK
+                 */
+                if (args->ins->server) {
+                    prepare_server_reply(&send_request, &receive_result, msg_syn_ack);
+                    nanoping_send_one(args->ins, &send_request, NULL, 0);
+                }
+                break;
             case msg_syn_ack:
                 if (atomic_load(&state) == msg_syn)
                     atomic_store(&state, msg_syn_ack);
@@ -825,14 +846,6 @@ static int run_client_ping_sequence(struct nanoping_instance *ins,
 
     return 0;
 
-}
-
-static void prepare_server_reply(struct nanoping_send_request *send_request,
-                                 const struct nanoping_receive_result *receive_result,
-                                 enum nanoping_msg_type msg_type) {
-    send_request->seq = receive_result->seq;
-    send_request->remaddr = receive_result->remaddr;
-    send_request->type = msg_type;
 }
 
 static enum timer_type select_default_timer(int delay_us)


### PR DESCRIPTION
Include several updates from the private development repository.

This includes:
- Improved server responses to packets
  - Will now resend "SYN-ACKs" also for reverse/duplex modes
  - Will check the that the src address of arriving packets match the client it connected to

- Some bug fixes and cleanup of unused code/features

- Additional options to improve fetching of HW TX timestamps
  - Can optionally read the error queue in a busy-loop instead of relying `select()`
  - Can pin each thread of the application to different cores to minimize CPU migration and contention between threads 

- Unified and improved the packet pacing mechanism
  - Same algorithm is now used to wait between packet transmissions for both fixed-interval (`--delay`) and variable-interval (`--probe-schedule`) cases
  - Option to further minimize drifting in case nanoprobe falls behind the intended schedule